### PR TITLE
add event and next_event queries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -774,3 +774,48 @@ Style/WhileUntilDo:
 Rails/Delegate:
   Description: 'Use `delegate` to define delegations.'
   Enabled: false
+
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/FindById:
+  Enabled: false
+
+Rails/Inquiry:
+  Enabled: true
+
+Rails/MailerName:
+  Enabled: true
+
+Rails/MatchRoute:
+  Enabled: true
+
+Rails/NegateInclude:
+  Enabled: true
+
+Rails/Pluck:
+  Enabled: true
+
+Rails/PluckInWhere:
+  Enabled: true
+
+Rails/RenderInline:
+  Enabled: true
+
+Rails/RenderPlainText:
+  Enabled: true
+
+Rails/ShortI18n:
+  Enabled: true
+
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+
+Rails/WhereExists:
+  Enabled: true
+
+Rails/WhereNot:
+  Enabled: true

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -10,5 +10,6 @@ module Types
     field :start_datetime, GraphQL::Types::ISO8601DateTime, null: false
     field :duration, Int, null: false
     field :description, String, null: true
+    field :slug, String, null: false
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -25,5 +25,12 @@ module Types
     def upcoming_events
       Event.upcoming_events
     end
+
+    field :next_event, UpcomingEventType, null: false, description: 'Query for next event' do
+      argument :slug, String, required: true
+    end
+    def next_event(slug:)
+      Event.find_by(slug: slug).next_event_occurrence_with_time
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,6 +2,13 @@
 module Types
   class QueryType < Types::BaseObject
 
+    field :event, EventType, null: false, description: 'Query an event' do
+      argument :slug, String, required: true
+    end
+    def event(slug:)
+      Event.find_by(slug: slug)
+    end
+
     field :events, [EventType], null: false, description: 'Query for all events' do
       argument :order_by, String, required: false
       argument :order_direction, String, required: false

--- a/spec/graphql/queries/next_event_spec.rb
+++ b/spec/graphql/queries/next_event_spec.rb
@@ -20,9 +20,9 @@ RSpec.describe 'Next Event' do
         }
       }
     GRAPHQL
-               
+
     result = WebsiteOneBackendApiSchema.execute(query_string)['data']['nextEvent']
-               
-    expect(result['event']['name']).to eq "Event Name"
+
+    expect(result['event']['name']).to eq 'Event Name'
   end
 end

--- a/spec/graphql/queries/next_event_spec.rb
+++ b/spec/graphql/queries/next_event_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+RSpec.describe 'Next Event' do
+
+  it 'queries and returns the next event' do
+    create(:event, name: 'Event Name',
+                   start_datetime: DateTime.yesterday,
+                   duration: '1',
+                   repeats: 'weekly')
+
+    query_string = <<-GRAPHQL
+    query
+      {
+        nextEvent(slug: "event-name") {
+          event {
+            id
+            name
+          }
+          time
+        }
+      }
+    GRAPHQL
+               
+    result = WebsiteOneBackendApiSchema.execute(query_string)['data']['nextEvent']
+               
+    expect(result['event']['name']).to eq "Event Name"
+  end
+end

--- a/spec/graphql/queries/show_event_spec.rb
+++ b/spec/graphql/queries/show_event_spec.rb
@@ -5,6 +5,25 @@ require 'graphql_helper'
 
 RSpec.describe 'Events' do
 
+  it 'queries and returns an event' do
+    create(:event, name: 'FirstEvent')
+
+    query_string = <<-GRAPHQL
+    query
+     {
+       event (slug: "firstevent") {
+          id
+          duration
+          name
+        }
+      }
+      GRAPHQL
+
+    result = WebsiteOneBackendApiSchema.execute(query_string)['data']['event']
+
+    expect(result['name']).to eq 'FirstEvent'
+  end
+
   it 'queries and returns all events' do
     create(:event, name: 'FirstEvent')
     create(:event, name: 'AnotherEvent')


### PR DESCRIPTION
Adds event graphql query by 'friendly name' (slug).
Add next_event graphql query by slug.

fixes #99
fixes #101 