### PR TITLE
Test sad path for next_event

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -30,7 +30,8 @@ module Types
       argument :slug, String, required: true
     end
     def next_event(slug:)
-      Event.find_by(slug: slug).next_event_occurrence_with_time
+      e = Event.find_by(slug: slug)
+      e.nil? ? e : e.next_event_occurrence_with_time
     end
   end
 end

--- a/spec/graphql/queries/next_event_spec.rb
+++ b/spec/graphql/queries/next_event_spec.rb
@@ -25,4 +25,33 @@ RSpec.describe 'Next Event' do
 
     expect(result['event']['name']).to eq 'Event Name'
   end
+
+  it 'queries and returns an appropriate error when no event exists ' do
+
+    query_string = <<-GRAPHQL
+    query
+      {
+        nextEvent(slug: "event-name-missing") {
+          event {
+            id
+            name
+          }
+          time
+        }
+      }
+    GRAPHQL
+
+    expected_result = {
+      'data' => nil,
+      'errors' => [
+        {
+          'message' => 'Cannot return null for non-nullable field Query.nextEvent'
+        }
+      ]
+    }
+
+    result = WebsiteOneBackendApiSchema.execute(query_string).to_h
+
+    expect(result).to eq expected_result
+  end
 end


### PR DESCRIPTION
Fixes issue with next_event when database record not found.  Adds a test for this.

fixes #106 


